### PR TITLE
Set the response X-Request-ID header to the provided value, if it's included in the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # RequestID
 
-Request ID middleware for Gin Framework. Adds an indentifier to the response using the `X-Request-ID` header
+Request ID middleware for Gin Framework. Adds an indentifier to the response using the `X-Request-ID` header.
+Passes the `X-Request-ID` value back to the caller if it's sent in the request headers.
 
 ## Config
 

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/google/uuid v1.1.1
+	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,7 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLD
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=

--- a/requestid.go
+++ b/requestid.go
@@ -33,12 +33,12 @@ func New(config ...Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Get id from request
 		rid := c.GetHeader(headerXRequestID)
-
 		if rid == "" {
 			rid = cfg.Generator()
-			c.Header(headerXRequestID, rid)
 		}
 
+		// Set the id to ensure that the requestid is in the response
+		c.Writer.Header().Set(headerXRequestID, rid)
 		c.Next()
 	}
 }

--- a/requestid_test.go
+++ b/requestid_test.go
@@ -1,1 +1,43 @@
 package requestid
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+const testXRequestID = "test-request-id"
+
+func emptySuccessResponse(c *gin.Context) {
+	c.String(200, "")
+}
+
+func Test_RequestID_CreateNew(t *testing.T) {
+	r := gin.New()
+	r.Use(New())
+	r.GET("/", emptySuccessResponse)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code)
+	assert.NotEmpty(t, w.Header().Get(headerXRequestID))
+}
+
+func Test_RequestID_PassThru(t *testing.T) {
+	r := gin.New()
+	r.Use(New())
+	r.GET("/", emptySuccessResponse)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set(headerXRequestID, testXRequestID)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, testXRequestID, w.Header().Get(headerXRequestID))
+}


### PR DESCRIPTION
RequestID PassThru

It would be beneficial to pass-thru incoming X-Request-ID values so that they are also included in the HTTP response and can be used for traceability.