### PR TITLE
Update requestid.go

### DIFF
--- a/requestid.go
+++ b/requestid.go
@@ -35,6 +35,8 @@ func New(config ...Config) gin.HandlerFunc {
 		rid := c.GetHeader(headerXRequestID)
 		if rid == "" {
 			rid = cfg.Generator()
+			// Set the id to ensure that the requestid is in the request
+			c.Request.Header.Add(headerXRequestID, rid)
 		}
 
 		// Set the id to ensure that the requestid is in the response


### PR DESCRIPTION
Set req id in the request if it does't exists so it can be logged easily with the default logger:

```
r.Use(gin.LoggerWithFormatter(func(param gin.LogFormatterParams) string {
    return fmt.Sprintf("%s\n", param.Request.Header.Get("X-Request-ID"))
}))
```