### PR TITLE
Add request id handler

### DIFF
--- a/_example/example02/main.go
+++ b/_example/example02/main.go
@@ -19,6 +19,9 @@ func main() {
 				return "test"
 			}),
 			requestid.WithCustomHeaderStrKey("your-customer-key"),
+			requestid.WithHandler(func(c *gin.Context, requestID string) {
+				log.Printf("RequestID: %s", requestID)
+			}),
 		),
 	)
 

--- a/options.go
+++ b/options.go
@@ -1,9 +1,14 @@
 package requestid
 
+import (
+	"github.com/gin-gonic/gin"
+)
+
 // Option for queue system
 type Option func(*config)
 
 type Generator func() string
+type Handler func(c *gin.Context, requestID string)
 
 type HeaderStrKey string
 
@@ -18,5 +23,12 @@ func WithGenerator(g Generator) Option {
 func WithCustomHeaderStrKey(s HeaderStrKey) Option {
 	return func(cfg *config) {
 		cfg.headerKey = s
+	}
+}
+
+// WithHandler set handler function for request id with context
+func WithHandler(handler Handler) Option {
+	return func(cfg *config) {
+		cfg.handler = handler
 	}
 }

--- a/requestid.go
+++ b/requestid.go
@@ -15,6 +15,7 @@ type config struct {
 	// }
 	generator Generator
 	headerKey HeaderStrKey
+	handler   Handler
 }
 
 // New initializes the RequestID middleware.
@@ -37,6 +38,9 @@ func New(opts ...Option) gin.HandlerFunc {
 			rid = cfg.generator()
 		}
 		headerXRequestID = string(cfg.headerKey)
+		if cfg.handler != nil {
+			cfg.handler(c, rid)
+		}
 		// Set the id to ensure that the requestid is in the response
 		c.Header(headerXRequestID, rid)
 		c.Next()

--- a/requestid_test.go
+++ b/requestid_test.go
@@ -79,3 +79,23 @@ func TestRequestIDWithCustomHeaderKey(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, testXRequestID, w.Header().Get("customKey"))
 }
+
+func TestRequestIDWithHandler(t *testing.T) {
+	r := gin.New()
+	called := false
+	r.Use(
+		New(
+			WithHandler(func(c *gin.Context, requestID string) {
+				called = true
+				assert.Equal(t, testXRequestID, requestID)
+			}),
+		),
+	)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/", nil)
+	req.Header.Set("X-Request-ID", testXRequestID)
+	r.ServeHTTP(w, req)
+
+	assert.True(t, called)
+}


### PR DESCRIPTION
Add request id handler after extracting(or generating).

We want to use the request id value like this example.

```go
func main() {
	r := gin.New()
	r.Use(
		requestid.New(
			requestid.WithHandler(func(c *gin.Context, requestID string) {
				logger := logging.Logger().With("x-request-id", requestID)
				c.Request.WithContext(logging.WithLogger(c.Request.Context(), logger))
			}),
		),
	)
}
```