### PR TITLE
Write to global variable once to prevent data races

### DIFF
--- a/requestid.go
+++ b/requestid.go
@@ -31,13 +31,14 @@ func New(opts ...Option) gin.HandlerFunc {
 		opt(cfg)
 	}
 
+	headerXRequestID = string(cfg.headerKey)
+
 	return func(c *gin.Context) {
 		// Get id from request
-		rid := c.GetHeader(string(cfg.headerKey))
+		rid := c.GetHeader(headerXRequestID)
 		if rid == "" {
 			rid = cfg.generator()
 		}
-		headerXRequestID = string(cfg.headerKey)
 		if cfg.handler != nil {
 			cfg.handler(c, rid)
 		}


### PR DESCRIPTION
**Before:**
We write to the global variable 'headerXRequestID' on every request. This leads to data races and a slight slowdown for each request.

**After:**
We write to the global variable 'headerXRequestID' once during the setup of the middleware.

For more details see issue #24 