### PR TITLE
[Docs] improve the documentation :: add missed ```

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ go get github.com/gin-contrib/requestid
 
 Import it in your code:
 
-````go
+```go
 import "github.com/gin-contrib/requestid"
-
+```
 ## Config
 
 define your custom generator function:


### PR DESCRIPTION
The readme is missing a **```**.

Current state of doc

<img width="450" alt="image" src="https://github.com/gin-contrib/requestid/assets/4077212/16e08044-bb10-40f8-8f72-ec25fb07b432">

After this Pr.

<img width="533" alt="image" src="https://github.com/gin-contrib/requestid/assets/4077212/b4eb8821-bd96-43b3-a104-0e014d5a22bf">
